### PR TITLE
[Blocker] Try to fix "Cannot read property 'Search' of undefined"

### DIFF
--- a/Resources/public/js/views/services/ezsearch-searchviewservice.js
+++ b/Resources/public/js/views/services/ezsearch-searchviewservice.js
@@ -1,4 +1,10 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
 YUI.add('ezsearch-searchviewservice', function (Y) {
+    "use strict";
+
     Y.namespace('eZSearch');
 
     Y.eZSearch.SearchViewService = Y.Base.create('ezsearchSearchViewService', Y.eZ.ViewService, [], {
@@ -52,7 +58,4 @@ YUI.add('ezsearch-searchviewservice', function (Y) {
             
         }
     });
-    Y.eZ.PluginRegistry.registerPlugin(
-        Y.eZ.Plugin.Search, ['ezsearchSearchViewService']
-    );
 });


### PR DESCRIPTION
Release blocker, error `Uncaught TypeError: Cannot read property 'Search' of undefined` stops UI from loading on the removed code block.

NOTE: This change just allows UI to load, however Search UI is not responding when trying to search.

To reproduce for instance install `ezstudio-demo:master` which bundles all protoype bundles:
https://github.com/ezsystems/ezstudio-demo _(see last commit if you want to apply to platform install)_

So we need proper fix from UI team: @StephaneDiot, @dpobel, or @yannickroger.
/cc @bdunogier 
